### PR TITLE
Fix loading HTML

### DIFF
--- a/loading.html
+++ b/loading.html
@@ -1,1 +1,9 @@
-Installing dependencies...
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    Installing dependencies...
+  </body>
+</html>


### PR DESCRIPTION
I know this is just a placeholder, but not having the charset and doctype tag causes unnecessary warnings in the console, which may trip up learners 