### PR TITLE
Tweak body and textarea styles of demo page

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,10 +2,14 @@
   box-sizing: border-box;
 }
 
+:root {
+  font-family: Inter, system-ui, Segoe UI, Roboto, Helvetica Neue, sans-serif;
+  color: black;
+  background: white;
+}
+
 body {
   margin: 0.5rem 1rem;
-  height: 100vh;
-  font-family: "Inter",-apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
 }
 
 header {
@@ -39,8 +43,10 @@ textarea {
   background: black;
   color: white;
   padding: 0.5rem 1rem;
-  font-size: 120%;
   margin-bottom: 10px;
+  font-size: 0.9rem;
+  line-height: 1.2rem;
+  font-family: Menlo, Cascadia Code, Consolas, Liberation Mono, monospace;
 }
 
 .container {


### PR DESCRIPTION
Found a couple issues:

1. Unnecessary scrollbar due to the `body` having `height: 100vh` plus top and bottom margins.
2. Textarea styles seem to assume a monospace font for `textarea`, but Safari uses a sans-serif font by default for `textarea` elements (unlike Chrome and Safari in my tests).

Before in Safari:

![safari-before](https://user-images.githubusercontent.com/243601/234117306-29570c17-5b04-47e5-88c0-caa89a56e2ab.png)

After in Safari:

![safari-after](https://user-images.githubusercontent.com/243601/234117336-d8893eba-b651-4177-996e-b3b85cb92cfb.png)
